### PR TITLE
Add tests for utils and grammar generation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install pytest
+      - run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+# Ensure src/python is on the path so ``kogen`` can be imported
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src/python'))

--- a/tests/test_procedural_dialog.py
+++ b/tests/test_procedural_dialog.py
@@ -1,0 +1,31 @@
+import re
+import sys
+import types
+
+
+def test_generate_dialog_output(capsys):
+    class SimpleGrammar:
+        @staticmethod
+        def parse(grammar):
+            pattern = re.compile(r'#(.*?)#')
+
+            def expand(text):
+                while True:
+                    match = pattern.search(text)
+                    if not match:
+                        return text
+                    key = match.group(1)
+                    replacement = expand(grammar[key][0])
+                    text = pattern.sub(replacement, text, count=1)
+
+            return expand(grammar['text'][0])
+
+    module = types.ModuleType('simplegrammar')
+    module.SimpleGrammar = SimpleGrammar
+    sys.modules['simplegrammar'] = module
+
+    from kogen.procedural_dialog import generate_dialog
+
+    generate_dialog()
+    captured = capsys.readouterr()
+    assert captured.out == '가:이것은의자입니까?\n나:이것은의자입니다.\n\n'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import types
+from kogen import utils
+
+
+def test_opposite_direction():
+    assert utils.opposite_direction('north') == 'south'
+    assert utils.opposite_direction('south') == 'north'
+    assert utils.opposite_direction('west') == 'east'
+    assert utils.opposite_direction('east') == 'west'
+
+
+def test_capitalize():
+    assert utils.capitalize('hello') == 'Hello'
+    assert utils.capitalize('a') == 'A'
+
+
+def test_is_int():
+    assert utils.is_int('123')
+    assert utils.is_int('-5')
+    assert not utils.is_int('3.14')
+    assert not utils.is_int('ten')
+
+
+def test_get_random(monkeypatch):
+    # force randint to return the upper bound to test edge behaviour
+    monkeypatch.setattr(utils, 'randint', lambda a, b: b)
+    data = [1, 2, 3]
+    assert utils.get_random(data) == data[-1]


### PR DESCRIPTION
## Summary
- add pytest tests for utility helpers
- stub simple grammar and test procedural dialog output
- add GitHub Actions workflow to run tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1ec0ffd7883338202329e1a880958